### PR TITLE
Add OpenRouter support via configurable baseURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,16 @@ A Visual Studio Code extension that allows developers to create code snippets us
 
 ## Usage
 
-* Get a OpenAI API key from https://platform.openai.com/account/api-keys
+* Get an API key — from OpenAI (https://platform.openai.com/account/api-keys) or any OpenAI-compatible provider such as OpenRouter (https://openrouter.ai/keys).
 * Create snippet file contains prompts, variable and functions.
 * Set your API key and snippet files path in the extension VSCode settings `File>Preferences>Settings>Extensions>OpenAI Powered Snippets`
 ![settings](/media/settings.png)
 * In the editor, left-click and select "Run OpenAI Snippet" or use the keyboard shortcut Ctrl+O+A.
+
+### Using OpenRouter (or any OpenAI-compatible provider)
+* Set `Base URL` to `https://openrouter.ai/api/v1`
+* Put your OpenRouter key in the `API Key` setting
+* Set `Model` to an OpenRouter model id, e.g. `anthropic/claude-sonnet-4.5`
 
 # Snippet Files
 To use prompts you need create snippet and set path in vscode settings.
@@ -24,6 +29,7 @@ these all valid for path settings:
  * C:\snippet_file_folder
  * C:\snippet_file_folder\name_of_snippet.yaml
  * https://remote_address/name_of_snippet.yaml
+ * https://gist.githubusercontent.com/&lt;user&gt;/&lt;id&gt;/raw/snippet.yaml (raw GitHub Gist URL)
  
 
 See sample files : https://github.com/faaydemir/openai-powered-snippets/tree/main/sample-snippet-files

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 				"openaipoweredsnippet.openAIToken": {
 					"type": "string",
 					"default": "",
-					"description": "Your openai token",
+					"description": "API key (OpenAI, OpenRouter, or any OpenAI-compatible provider)",
 					"order": 1
 				},
 				"openaipoweredsnippet.snippetFiles": {
@@ -64,8 +64,8 @@
 				},
 				"openaipoweredsnippet.openAIModel": {
 					"type": "string",
-					"default": "gpt-3.5-turbo",
-					"description": "openai model",
+					"default": "gpt-5-mini",
+					"description": "Model name. Examples: gpt-5-mini (OpenAI); anthropic/claude-sonnet-4.5 (OpenRouter).",
 					"order": 3
 				},
 				"openaipoweredsnippet.baseURL": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 				"openaipoweredsnippet.snippetFiles": {
 					"type": "string",
 					"default": "",
-					"description": "Path for user defined snippet files. For multiple path seperate with ';'  C:\\MySnipFolder1;C:\\MySnipFolder2\\snip.js",
+					"description": "Path(s) or URL(s) to snippet files. Local path, folder, HTTP URL, or raw GitHub Gist URL. Separate multiple with ';'.",
 					"order": 2
 				},
 				"openaipoweredsnippet.openAIModel": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,12 @@
 					"default": "gpt-3.5-turbo",
 					"description": "openai model",
 					"order": 3
+				},
+				"openaipoweredsnippet.baseURL": {
+					"type": "string",
+					"default": "",
+					"description": "Optional base URL for OpenAI-compatible API (e.g. https://openrouter.ai/api/v1 for OpenRouter). Leave empty to use OpenAI.",
+					"order": 4
 				}
 			}
 		}

--- a/src/core/openai-client.js
+++ b/src/core/openai-client.js
@@ -24,9 +24,21 @@ export class OpenAIAnswer {
     }
 }
 
-export function setOpenAIApiKey(apiKey) {
-    configuration = new Configuration({ apiKey });
+let basePath;
+
+function rebuildClient(apiKey) {
+    configuration = new Configuration({ apiKey, basePath });
     openai = new OpenAIApi(configuration);
+}
+
+let currentApiKey;
+export function setOpenAIApiKey(apiKey) {
+    currentApiKey = apiKey;
+    rebuildClient(apiKey);
+}
+export function setOpenAIBaseURL(url) {
+    basePath = url || undefined;
+    rebuildClient(currentApiKey);
 }
 export function setOpenAIModel(openAImodel) {
     model = openAImodel;
@@ -61,7 +73,7 @@ export async function askToOpenAIDavinci(prompt) {
 export async function askToOpenAIGPT(prompt) {
     try {
         const response = await openai.createChatCompletion({
-            model: "gpt-3.5-turbo",
+            model: model,
             messages: [
                 { role: "user", content: prompt },
             ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import Variable from './core/variable';
 import getCommandRunnerContext, { CommandRunnerContext } from './core/command-runner-context';
-import { setOpenAIApiKey, setOpenAIModel } from './core/openai-client';
+import { setOpenAIApiKey, setOpenAIModel, setOpenAIBaseURL } from './core/openai-client';
 import GenericWebViewPanel from './vscode-functions/webview-panel';
 import importSnippets from './core/importSnippets';
 import getSelectedText from './vscode-functions/get-selected-text';
@@ -30,6 +30,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	const config = initConfiguration();
 	//TODO: make baseFolder lazy
 	initSnippetSystemVariables();
+	setOpenAIBaseURL(config.get('baseURL'));
 	setOpenAIApiKey(config.get('openAIToken'));
 	setOpenAIModel(config.get('openAIModel'));
 


### PR DESCRIPTION
Adds a `baseURL` setting so any OpenAI-compatible provider (e.g. OpenRouter) works. Default model bumped to `gpt-5-mini`. README mentions OpenRouter and raw Gist URLs as snippet sources.