### PR TITLE
Handle provider base URLs more reliably

### DIFF
--- a/src/core/openai-client.js
+++ b/src/core/openai-client.js
@@ -44,6 +44,21 @@ export function setOpenAIModel(openAImodel) {
     model = openAImodel;
 }
 
+function getErrorDetail(error) {
+    const responseError = error?.response?.data?.error;
+    const message = responseError?.message || error?.response?.data?.message || error?.message;
+    const code = responseError?.code || error?.code;
+    const status = error?.response?.status;
+    const details = [status && `HTTP ${status}`, code, message].filter(Boolean);
+
+    return details.join(" - ") || "Unknown provider error";
+}
+
+function throwProviderError(error) {
+    console.error(error);
+    throw new Error(`AI provider request failed: ${getErrorDetail(error)}`);
+}
+
 
 /**
  * @param  {String} prompt
@@ -62,7 +77,7 @@ export async function askToOpenAIDavinci(prompt) {
         });
         return new OpenAIAnswer(response.data.choices[0].text);
     } catch (error) {
-        console.error(error);
+        throwProviderError(error);
     }
 }
 
@@ -82,7 +97,7 @@ export async function askToOpenAIGPT(prompt) {
         });
         return new OpenAIAnswer(response.data.choices[0].message.content);
     } catch (error) {
-        console.error(error);
+        throwProviderError(error);
     }
 }
 

--- a/src/core/openai-client.js
+++ b/src/core/openai-client.js
@@ -37,7 +37,7 @@ export function setOpenAIApiKey(apiKey) {
     rebuildClient(apiKey);
 }
 export function setOpenAIBaseURL(url) {
-    basePath = url || undefined;
+    basePath = url?.replace(/\/+$/, "") || undefined;
     rebuildClient(currentApiKey);
 }
 export function setOpenAIModel(openAImodel) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,14 +113,20 @@ let extensionConfig: { [key: string]: string | undefined; } = {};
 function initConfiguration() {
 
 	vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
-		if (event.affectsConfiguration('"openaipoweredsnippet.openAIToken')) {
-			const config = vscode.workspace.getConfiguration('openaipoweredsnippet');
+		const config = vscode.workspace.getConfiguration('openaipoweredsnippet');
+		if (event.affectsConfiguration('openaipoweredsnippet.openAIToken')) {
 			setOpenAIApiKey(config.get('openAIToken') as string | undefined);
 			if (!config.get('openAIToken')) {
 				log.error("Open AI api key required");
 			}
-		} else if (event.affectsConfiguration('openaipoweredsnippet.snippetFiles')) {
-			const config = vscode.workspace.getConfiguration('openaipoweredsnippet');
+		}
+		if (event.affectsConfiguration('openaipoweredsnippet.openAIModel')) {
+			setOpenAIModel(config.get('openAIModel') as string | undefined);
+		}
+		if (event.affectsConfiguration('openaipoweredsnippet.baseURL')) {
+			setOpenAIBaseURL(config.get('baseURL') as string | undefined);
+		}
+		if (event.affectsConfiguration('openaipoweredsnippet.snippetFiles')) {
 			importSnippets(config.get('snippetFiles'));
 			if (!config.get('snippetFiles')) {
 				log.error("SnippetFile key required");


### PR DESCRIPTION
Small provider configuration fixes.

The main change removes trailing slashes from the configured base URL. With the current OpenAI SDK, a URL such as `https://openrouter.ai/api/v1/` otherwise becomes `https://openrouter.ai/api/v1//chat/completions` and returns 404.

This also keeps provider settings updated without restarting VS Code and surfaces the original provider error instead of only showing a generic message.

Checks:
- `npm run compile`
- `npm run lint`
- Live OpenRouter request with a trailing-slash base URL